### PR TITLE
feat(provider): support *_BASE_URL env vars to override API endpoints

### DIFF
--- a/crates/cersei-provider/src/anthropic.rs
+++ b/crates/cersei-provider/src/anthropic.rs
@@ -24,9 +24,13 @@ pub struct Anthropic {
 
 impl Anthropic {
     pub fn new(auth: Auth) -> Self {
+        let base_url = std::env::var("ANTHROPIC_BASE_URL")
+            .ok()
+            .filter(|u| !u.is_empty())
+            .unwrap_or_else(|| ANTHROPIC_API_BASE.to_string());
         Self {
             auth,
-            base_url: ANTHROPIC_API_BASE.to_string(),
+            base_url,
             default_model: "claude-sonnet-4-6".to_string(),
             thinking_budget: None,
             max_retries: 5,

--- a/crates/cersei-provider/src/gemini.rs
+++ b/crates/cersei-provider/src/gemini.rs
@@ -22,9 +22,13 @@ pub struct Gemini {
 
 impl Gemini {
     pub fn new(api_key: impl Into<String>) -> Self {
+        let base_url = std::env::var("GEMINI_BASE_URL")
+            .ok()
+            .filter(|u| !u.is_empty())
+            .unwrap_or_else(|| GEMINI_API_BASE.to_string());
         Self {
             api_key: api_key.into(),
-            base_url: GEMINI_API_BASE.to_string(),
+            base_url,
             default_model: "gemini-3.1-pro-preview".to_string(),
             client: reqwest::Client::new(),
         }

--- a/crates/cersei-provider/src/openai.rs
+++ b/crates/cersei-provider/src/openai.rs
@@ -16,9 +16,13 @@ pub struct OpenAi {
 
 impl OpenAi {
     pub fn new(auth: Auth) -> Self {
+        let base_url = std::env::var("OPENAI_BASE_URL")
+            .ok()
+            .filter(|u| !u.is_empty())
+            .unwrap_or_else(|| OPENAI_API_BASE.to_string());
         Self {
             auth,
-            base_url: OPENAI_API_BASE.to_string(),
+            base_url,
             default_model: "gpt-4o".to_string(),
             client: reqwest::Client::new(),
         }


### PR DESCRIPTION
## Summary

- Adds `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, and `GEMINI_BASE_URL` env var support
- Each provider's `new()` constructor checks the env var first, falls back to the hardcoded default when unset or empty
- All code paths (`from_env`, router, builder) benefit automatically — zero breaking changes

## Motivation

Users running compatible third-party endpoints (e.g. [z.ai](https://z.ai), Azure OpenAI, custom proxies) currently have no way to override the hardcoded base URL without rebuilding. The docs already document `OPENAI_BASE_URL` as a pattern but it was never implemented.

## Test plan

- [ ] `ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic abstract` routes to z.ai
- [ ] `OPENAI_BASE_URL=https://custom.endpoint/v1 abstract --model gpt-4o` routes correctly
- [ ] Unset env var falls back to default — no regression
- [ ] Empty string env var treated as unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)