### PR TITLE
Added note about async-trait and cersei-tools in README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,15 @@ cersei::tools::orchestration() // SendMessage, Tasks (6 tools), Worktree
 
 Custom tools in 10 lines:
 
+> The `#[derive(Tool)]` macro generates code with `#[async_trait::async_trait]` and `cercei-tools`, to make it work add both of it to depending on your project.
+>  ```toml
+> async-trait = "0.1"
+> cersei = { path = "path/to/cersei" } # or git
+> cersei-tools = { path = "path/to/cersei/crates/cersei-tools" }
+> ```
+> or write `use cersei::tools as cersei_tools;` when using `derive(Tool)`;
+    
+
 ```rust
 #[derive(Tool)]
 #[tool(name = "search", description = "Search docs", permission = "read_only")]


### PR DESCRIPTION
Hi, Adib! I like your project, it looks very promising.

I ran into an issue with imports: for `#[derive(Tool)]` to work (despite the re-export in cersei), I had to explicitly add `async-trait` and `cersei_tools` to the project. So I added a note to the README file.

~~I understand how to fix this with a local installation, but I couldn't get it to work with Git~~.
Can be used  `use cersei::tools as cersei_tools`.

<details>
<summary>Error msg.</summary>

```
cannot find module or crate `async_trait` in this scope
use of unresolved module or unlinked crate `async_trait` [E0433]
cannot find module or crate `cersei_tools` in this scope
if you wanted to use a crate named `cersei_tools`, use `cargo add cersei_tools` to add it to your `Cargo.toml` [E0433]
```
</details>

Or, it be resolved if change `async_trait::async_trait` to `async_trait` in [cersei-tools-derive/src/lib.rs ](https://github.com/pacifio/cersei/blob/8e93da2990a73402428e5dab173cda37b56c8cbe/crates/cersei-tools-derive/src/lib.rs#L72)