### PR TITLE
P3: surface compression savings, seed usage, OpenAI reasoning_effort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 authors = ["Adib Mohsin"]
 license = "MIT"
@@ -101,23 +101,23 @@ quote = "1"
 proc-macro2 = "1"
 
 # Workspace crates
-cersei = { path = "crates/cersei", version = "0.2.5" }
-cersei-types = { path = "crates/cersei-types", version = "0.2.5" }
-cersei-provider = { path = "crates/cersei-provider", version = "0.2.5" }
-cersei-tools = { path = "crates/cersei-tools", version = "0.2.5" }
-cersei-tools-derive = { path = "crates/cersei-tools-derive", version = "0.2.5" }
-cersei-agent = { path = "crates/cersei-agent", version = "0.2.5" }
-cersei-memory = { path = "crates/cersei-memory", version = "0.2.5" }
-cersei-hooks = { path = "crates/cersei-hooks", version = "0.2.5" }
-cersei-mcp = { path = "crates/cersei-mcp", version = "0.2.5" }
-cersei-lsp = { path = "crates/cersei-lsp", version = "0.2.5" }
-cersei-embeddings = { path = "crates/cersei-embeddings", version = "0.2.5" }
-cersei-compression = { path = "crates/cersei-compression", version = "0.2.5" }
-cersei-skills = { path = "crates/cersei-skills", version = "0.2.5" }
-cersei-vms = { path = "crates/cersei-vms", version = "0.2.5" }
-cersei-agentlang = { path = "crates/cersei-agentlang", version = "0.2.5" }
-cersei-agentrl = { path = "crates/cersei-agentrl", version = "0.2.5" }
-cersei-workflows = { path = "crates/cersei-workflows", version = "0.2.5" }
+cersei = { path = "crates/cersei", version = "0.2.6" }
+cersei-types = { path = "crates/cersei-types", version = "0.2.6" }
+cersei-provider = { path = "crates/cersei-provider", version = "0.2.6" }
+cersei-tools = { path = "crates/cersei-tools", version = "0.2.6" }
+cersei-tools-derive = { path = "crates/cersei-tools-derive", version = "0.2.6" }
+cersei-agent = { path = "crates/cersei-agent", version = "0.2.6" }
+cersei-memory = { path = "crates/cersei-memory", version = "0.2.6" }
+cersei-hooks = { path = "crates/cersei-hooks", version = "0.2.6" }
+cersei-mcp = { path = "crates/cersei-mcp", version = "0.2.6" }
+cersei-lsp = { path = "crates/cersei-lsp", version = "0.2.6" }
+cersei-embeddings = { path = "crates/cersei-embeddings", version = "0.2.6" }
+cersei-compression = { path = "crates/cersei-compression", version = "0.2.6" }
+cersei-skills = { path = "crates/cersei-skills", version = "0.2.6" }
+cersei-vms = { path = "crates/cersei-vms", version = "0.2.6" }
+cersei-agentlang = { path = "crates/cersei-agentlang", version = "0.2.6" }
+cersei-agentrl = { path = "crates/cersei-agentrl", version = "0.2.6" }
+cersei-workflows = { path = "crates/cersei-workflows", version = "0.2.6" }
 
 # Google Cloud auth (service-account → self-refreshing OAuth tokens for Vertex).
 # rustls only — keeps the static-musl build OpenSSL-free.

--- a/crates/abstract-cli/src/render.rs
+++ b/crates/abstract-cli/src/render.rs
@@ -241,6 +241,7 @@ pub fn print_json_event(event: &cersei_agent::events::AgentEvent) {
             result,
             is_error,
             duration,
+            ..
         } => {
             serde_json::json!({"type": "tool_end", "name": name, "id": id, "result": result, "is_error": is_error, "duration_ms": duration.as_millis() as u64})
         }

--- a/crates/abstract-cli/src/repl.rs
+++ b/crates/abstract-cli/src/repl.rs
@@ -315,6 +315,7 @@ async fn run_agent_streaming(
                 result,
                 is_error,
                 duration,
+                ..
             } => {
                 renderer.tool_end(&name, &result, is_error, duration);
             }

--- a/crates/abstract-cli/src/tui/event_loop.rs
+++ b/crates/abstract-cli/src/tui/event_loop.rs
@@ -455,6 +455,7 @@ fn handle_agent_event(state: &mut AppState, event: AgentEvent) {
             result,
             is_error,
             duration,
+            ..
         } => {
             if let Some(tool) = state.active_tools.iter_mut().rev().find(|t| t.name == name) {
                 tool.status = if is_error {

--- a/crates/cersei-agent/src/events.rs
+++ b/crates/cersei-agent/src/events.rs
@@ -28,6 +28,9 @@ pub enum AgentEvent {
         result: String,
         is_error: bool,
         duration: Duration,
+        /// RTK compression metrics for this tool output, when compression ran
+        /// (None for error results, which are not compressed).
+        compression: Option<cersei_compression::CompressionStats>,
     },
     ToolPermissionCheck {
         name: String,

--- a/crates/cersei-agent/src/lib.rs
+++ b/crates/cersei-agent/src/lib.rs
@@ -217,6 +217,7 @@ pub struct AgentBuilder {
     max_tokens: u32,
     temperature: Option<f32>,
     thinking_budget: Option<u32>,
+    seed_usage: Option<Usage>,
     working_dir: Option<PathBuf>,
     permission_policy: Option<Arc<dyn PermissionPolicy>>,
     memory: Option<Arc<dyn Memory>>,
@@ -250,6 +251,7 @@ impl Default for AgentBuilder {
             max_tokens: 16384,
             temperature: None,
             thinking_budget: None,
+            seed_usage: None,
             working_dir: None,
             permission_policy: None,
             memory: None,
@@ -329,6 +331,13 @@ impl AgentBuilder {
 
     pub fn thinking_budget(mut self, tokens: u32) -> Self {
         self.thinking_budget = Some(tokens);
+        self
+    }
+
+    /// Seed the agent's cumulative token/cost usage. Use this when rebuilding an
+    /// agent per turn so cumulative totals carry over instead of resetting to zero.
+    pub fn with_cumulative_usage(mut self, usage: Usage) -> Self {
+        self.seed_usage = Some(usage);
         self
     }
 
@@ -485,7 +494,9 @@ impl AgentBuilder {
             messages: Arc::new(parking_lot::Mutex::new(
                 self.initial_messages.unwrap_or_default(),
             )),
-            cumulative_usage: Arc::new(parking_lot::Mutex::new(Usage::default())),
+            cumulative_usage: Arc::new(parking_lot::Mutex::new(
+                self.seed_usage.unwrap_or_default(),
+            )),
             cancel_token: self
                 .cancel_token
                 .unwrap_or_else(tokio_util::sync::CancellationToken::new),
@@ -496,5 +507,59 @@ impl AgentBuilder {
     /// Build + run in one shot.
     pub async fn run_with(self, prompt: &str) -> cersei_types::Result<AgentOutput> {
         self.build()?.run(prompt).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cersei_provider::{
+        CompletionRequest, CompletionStream, ProviderCapabilities, Provider,
+    };
+
+    /// Minimal provider that never produces output — enough to `build()` an agent.
+    struct StubProvider;
+
+    #[async_trait::async_trait]
+    impl Provider for StubProvider {
+        fn name(&self) -> &str {
+            "stub"
+        }
+        fn context_window(&self, _model: &str) -> u64 {
+            1000
+        }
+        fn capabilities(&self, _model: &str) -> ProviderCapabilities {
+            ProviderCapabilities::default()
+        }
+        async fn complete(&self, _request: CompletionRequest) -> cersei_types::Result<CompletionStream> {
+            let (_tx, rx) = tokio::sync::mpsc::channel(1);
+            Ok(CompletionStream::new(rx))
+        }
+    }
+
+    #[test]
+    fn cumulative_usage_defaults_to_zero() {
+        let agent = Agent::builder().provider(StubProvider).build().unwrap();
+        assert_eq!(agent.usage().input_tokens, 0);
+        assert_eq!(agent.usage().output_tokens, 0);
+    }
+
+    #[test]
+    fn seeded_cumulative_usage_is_restored() {
+        let seed = Usage {
+            input_tokens: 1234,
+            output_tokens: 567,
+            total_tokens: 1801,
+            ..Default::default()
+        };
+        let agent = Agent::builder()
+            .provider(StubProvider)
+            .with_cumulative_usage(seed.clone())
+            .build()
+            .unwrap();
+        let restored = agent.usage();
+        assert_eq!(restored.input_tokens, 1234);
+        assert_eq!(restored.output_tokens, 567);
+        assert_eq!(restored.total_tokens, 1801);
     }
 }

--- a/crates/cersei-agent/src/runner.rs
+++ b/crates/cersei-agent/src/runner.rs
@@ -747,6 +747,22 @@ pub async fn run_agent_streaming(
                         tool_error_counts.remove(&tool_name);
                     }
 
+                    // Compress before emitting ToolEnd so the savings stats ride
+                    // along on the event (error results are not compressed).
+                    let (capped_content, compression) = if result.is_error {
+                        (result.content.clone(), None)
+                    } else {
+                        let level = *agent.compression_level.lock();
+                        let (compressed, stats) =
+                            cersei_compression::compress_tool_output_with_stats(
+                                &tool_name,
+                                &tool_input,
+                                &result.content,
+                                level,
+                            );
+                        (cap_tool_result(&compressed), Some(stats))
+                    };
+
                     let _ = event_tx
                         .send(AgentEvent::ToolEnd {
                             name: tool_name.clone(),
@@ -754,6 +770,7 @@ pub async fn run_agent_streaming(
                             result: result.content.clone(),
                             is_error: result.is_error,
                             duration,
+                            compression,
                         })
                         .await;
                     agent.emit(AgentEvent::ToolEnd {
@@ -762,20 +779,8 @@ pub async fn run_agent_streaming(
                         result: result.content.clone(),
                         is_error: result.is_error,
                         duration,
+                        compression,
                     });
-
-                    let capped_content = if result.is_error {
-                        result.content.clone()
-                    } else {
-                        let level = *agent.compression_level.lock();
-                        let compressed = cersei_compression::compress_tool_output(
-                            &tool_name,
-                            &tool_input,
-                            &result.content,
-                            level,
-                        );
-                        cap_tool_result(&compressed)
-                    };
 
                     tool_calls.push(ToolCallRecord {
                         name: tool_name,

--- a/crates/cersei-compression/src/dispatch.rs
+++ b/crates/cersei-compression/src/dispatch.rs
@@ -7,9 +7,41 @@
 //! with `RUST_LOG=cersei_compression=info`.
 
 use crate::{ansi, code, level::CompressionLevel, toml_rules, truncate};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 const MAX_LINES_SAFETY: usize = 600;
+
+/// Structured before/after compression metrics for a single tool output.
+/// Surfaced on the event stream so consumers don't have to scrape the log line.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct CompressionStats {
+    pub before_bytes: usize,
+    pub after_bytes: usize,
+    pub before_lines: usize,
+    pub after_lines: usize,
+    /// Percentage of bytes removed (0.0 when nothing was compressed).
+    pub savings_pct: f64,
+}
+
+impl CompressionStats {
+    fn measure(before: &str, after: &str) -> Self {
+        let before_bytes = before.len();
+        let after_bytes = after.len();
+        let savings_pct = if before_bytes > 0 {
+            100.0 * (before_bytes as f64 - after_bytes as f64) / before_bytes as f64
+        } else {
+            0.0
+        };
+        Self {
+            before_bytes,
+            after_bytes,
+            before_lines: before.lines().count(),
+            after_lines: after.lines().count(),
+            savings_pct,
+        }
+    }
+}
 
 /// Infallible entry point. On any internal panic-free error we fall back to
 /// the raw content unchanged so the agent loop never breaks.
@@ -19,8 +51,20 @@ pub fn compress_tool_output(
     content: &str,
     level: CompressionLevel,
 ) -> String {
+    compress_tool_output_with_stats(tool_name, tool_input, content, level).0
+}
+
+/// Like [`compress_tool_output`], but also returns the [`CompressionStats`] so
+/// callers can surface the savings (e.g. on an event) instead of scraping the
+/// `cersei_compression` log line.
+pub fn compress_tool_output_with_stats(
+    tool_name: &str,
+    tool_input: &Value,
+    content: &str,
+    level: CompressionLevel,
+) -> (String, CompressionStats) {
     if level.is_off() || content.is_empty() {
-        return content.to_string();
+        return (content.to_string(), CompressionStats::measure(content, content));
     }
 
     let lowered = tool_name.to_ascii_lowercase();
@@ -73,8 +117,9 @@ pub fn compress_tool_output(
         }
     };
 
-    log_compression(tool_name, level, strategy, &detail, content, &out);
-    out
+    let stats = CompressionStats::measure(content, &out);
+    log_compression(tool_name, level, strategy, &detail, &stats);
+    (out, stats)
 }
 
 /// Returns (filtered_output, matched_rule_name_or_empty).
@@ -106,30 +151,19 @@ fn log_compression(
     level: CompressionLevel,
     strategy: &str,
     detail: &str,
-    before: &str,
-    after: &str,
+    stats: &CompressionStats,
 ) {
-    let before_bytes = before.len();
-    let after_bytes = after.len();
-    let before_lines = before.lines().count();
-    let after_lines = after.lines().count();
-    let savings_pct = if before_bytes > 0 {
-        100.0 * (before_bytes as f64 - after_bytes as f64) / before_bytes as f64
-    } else {
-        0.0
-    };
-
     tracing::info!(
         target: "cersei_compression",
         tool,
         level = %level,
         strategy,
         detail,
-        before_bytes,
-        after_bytes,
-        before_lines,
-        after_lines,
-        savings_pct = format!("{savings_pct:.1}"),
+        before_bytes = stats.before_bytes,
+        after_bytes = stats.after_bytes,
+        before_lines = stats.before_lines,
+        after_lines = stats.after_lines,
+        savings_pct = format!("{:.1}", stats.savings_pct),
         "tool-output compressed"
     );
 }
@@ -144,6 +178,30 @@ mod tests {
         let raw = "\x1b[31mhello\x1b[0m";
         let out = compress_tool_output("Bash", &json!({}), raw, CompressionLevel::Off);
         assert_eq!(out, raw);
+    }
+
+    #[test]
+    fn stats_report_byte_savings() {
+        let raw = "\x1b[31mfatal: not a git repo\x1b[0m";
+        let (out, stats) = compress_tool_output_with_stats(
+            "Bash",
+            &json!({ "command": "git status" }),
+            raw,
+            CompressionLevel::Minimal,
+        );
+        assert_eq!(stats.before_bytes, raw.len());
+        assert_eq!(stats.after_bytes, out.len());
+        assert!(out.len() < raw.len(), "expected ANSI stripping to shrink output");
+        assert!(stats.savings_pct > 0.0, "savings_pct should be positive: {stats:?}");
+    }
+
+    #[test]
+    fn stats_zero_savings_when_off() {
+        let raw = "hello world";
+        let (_out, stats) =
+            compress_tool_output_with_stats("Bash", &json!({}), raw, CompressionLevel::Off);
+        assert_eq!(stats.savings_pct, 0.0);
+        assert_eq!(stats.before_bytes, stats.after_bytes);
     }
 
     #[test]

--- a/crates/cersei-compression/src/lib.rs
+++ b/crates/cersei-compression/src/lib.rs
@@ -12,5 +12,5 @@ pub mod level;
 pub mod toml_rules;
 pub mod truncate;
 
-pub use dispatch::compress_tool_output;
+pub use dispatch::{compress_tool_output, compress_tool_output_with_stats, CompressionStats};
 pub use level::CompressionLevel;

--- a/crates/cersei-provider/src/openai.rs
+++ b/crates/cersei-provider/src/openai.rs
@@ -250,6 +250,13 @@ impl Provider for OpenAi {
             body["temperature"] = serde_json::json!(temp);
         }
 
+        // Reasoning effort: provider-agnostic `reasoning_effort` option
+        // ("minimal"/"low"/"medium"/"high"), mapped onto the OpenAI request body.
+        // Only the o-series / gpt-5 reasoning models accept it.
+        if let Some(effort) = reasoning_effort_for(&model, &request.options) {
+            body["reasoning_effort"] = serde_json::json!(effort);
+        }
+
         if !request.tools.is_empty() {
             let tools: Vec<serde_json::Value> = request
                 .tools
@@ -536,6 +543,18 @@ fn openai_file_part(source: &DocumentSource) -> Option<serde_json::Value> {
     }))
 }
 
+/// Resolve the OpenAI `reasoning_effort` request field from the provider-agnostic
+/// `reasoning_effort` option, gated to models that accept it (o-series / gpt-5).
+/// Returns `None` (omit the field) for non-reasoning models or when unset.
+fn reasoning_effort_for(model: &str, options: &ProviderOptions) -> Option<String> {
+    let reasoning_model =
+        model.starts_with("gpt-5") || model.starts_with("o1") || model.starts_with("o3");
+    if !reasoning_model {
+        return None;
+    }
+    options.get::<String>("reasoning_effort")
+}
+
 // ─── Builder ─────────────────────────────────────────────────────────────────
 
 #[derive(Default)]
@@ -622,5 +641,19 @@ mod multimodal_tests {
         let part = openai_file_part(&source).unwrap();
         assert_eq!(part["type"], "file");
         assert_eq!(part["file"]["file_data"], "data:application/pdf;base64,UERG");
+    }
+
+    #[test]
+    fn reasoning_effort_only_on_reasoning_models_when_set() {
+        let mut opts = ProviderOptions::default();
+        opts.set("reasoning_effort", "high");
+
+        // Reasoning models map the option through...
+        assert_eq!(reasoning_effort_for("gpt-5.3", &opts).as_deref(), Some("high"));
+        assert_eq!(reasoning_effort_for("o3-mini", &opts).as_deref(), Some("high"));
+        // ...non-reasoning models omit it...
+        assert_eq!(reasoning_effort_for("gpt-4o", &opts), None);
+        // ...and an unset option omits it even on reasoning models.
+        assert_eq!(reasoning_effort_for("gpt-5.3", &ProviderOptions::default()), None);
     }
 }


### PR DESCRIPTION
P3.1 — Add CompressionStats + compress_tool_output_with_stats; the RTK savings (before/after bytes+lines, savings_pct) are now a typed field on AgentEvent::ToolEnd instead of only a tracing log line. Compression now runs before ToolEnd is emitted so the stats ride along.

P3.2 — Add AgentBuilder::with_cumulative_usage(Usage) so an agent rebuilt per turn restores prior token/cost totals instead of resetting to zero.

P3.3 — Map a provider-agnostic `reasoning_effort` option onto the OpenAI request body (gated to o-series / gpt-5 reasoning models).

Adds unit tests for each; updates abstract-cli ToolEnd destructures.