### PR TITLE
Add MiniMax provider registry entry

### DIFF
--- a/crates/cersei-provider/src/registry.rs
+++ b/crates/cersei-provider/src/registry.rs
@@ -4,7 +4,6 @@
 //! API format (Anthropic or OpenAI-compatible), and known models with
 //! context windows.
 
-
 /// API format used by a provider.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ApiFormat {
@@ -328,6 +327,24 @@ pub static REGISTRY: &[ProviderEntry] = &[
         }],
     },
     ProviderEntry {
+        id: "minimax",
+        name: "MiniMax",
+        api_base: "https://api.minimax.io/v1",
+        env_keys: &["MINIMAX_API_KEY", "MINIMAX_KEY"],
+        api_format: ApiFormat::OpenAiCompatible,
+        default_model: "MiniMax-M3",
+        models: &[
+            ModelEntry {
+                id: "MiniMax-M3",
+                context_window: 1_000_000,
+            },
+            ModelEntry {
+                id: "MiniMax-M2.7",
+                context_window: 204_800,
+            },
+        ],
+    },
+    ProviderEntry {
         id: "together",
         name: "Together",
         api_base: "https://api.together.xyz/v1",
@@ -507,6 +524,22 @@ mod tests {
         std::env::remove_var("OPENAI_BASE_URL");
         assert_eq!(base, "https://api.deepseek.com/v1"); // trailing slash trimmed
         assert!(!base.contains("api.openai.com"));
+    }
+
+    #[test]
+    fn minimax_resolves_global_base_by_default() {
+        let entry = lookup("minimax").unwrap();
+        std::env::remove_var("MINIMAX_BASE_URL");
+        assert_eq!(entry.resolved_api_base(), "https://api.minimax.io/v1");
+    }
+
+    #[test]
+    fn minimax_base_url_override_supports_regional_endpoint() {
+        let entry = lookup("minimax").unwrap();
+        std::env::set_var("MINIMAX_BASE_URL", "https://api.minimaxi.com/v1/");
+        let base = entry.resolved_api_base();
+        std::env::remove_var("MINIMAX_BASE_URL");
+        assert_eq!(base, "https://api.minimaxi.com/v1");
     }
 
     #[test]

--- a/crates/cersei-provider/src/router.rs
+++ b/crates/cersei-provider/src/router.rs
@@ -177,6 +177,7 @@ fn auto_detect(model: &str) -> Result<(&'static ProviderEntry, &str)> {
         m if m.starts_with("mistral-") || m.starts_with("codestral-") => Some("mistral"),
         m if m.starts_with("deepseek-") => Some("deepseek"),
         m if m.starts_with("grok-") => Some("xai"),
+        m if m.starts_with("MiniMax-") => Some("minimax"),
         m if m.starts_with("command-") => Some("cohere"),
         m if m.starts_with("llama") => {
             // llama models could be on Groq, Together, etc.
@@ -268,6 +269,16 @@ mod tests {
     }
 
     #[test]
+    fn test_minimax_registry_entry() {
+        let entry = registry::lookup("minimax").unwrap();
+        assert_eq!(entry.name, "MiniMax");
+        assert_eq!(entry.default_model, "MiniMax-M3");
+        assert_eq!(entry.api_format, ApiFormat::OpenAiCompatible);
+        assert_eq!(entry.context_window("MiniMax-M3"), 1_000_000);
+        assert_eq!(entry.context_window("MiniMax-M2.7"), 204_800);
+    }
+
+    #[test]
     fn test_registry_lookup_new_providers() {
         assert!(registry::lookup("cohere").is_some());
         assert!(registry::lookup("sambanova").is_some());
@@ -287,6 +298,14 @@ mod tests {
             .unwrap_or_else(|_| (registry::lookup("cohere").unwrap(), "command-r-plus"));
         assert_eq!(entry.id, "cohere");
         assert_eq!(model, "command-r-plus");
+    }
+
+    #[test]
+    fn test_auto_detect_minimax() {
+        let (entry, model) = auto_detect("MiniMax-M3")
+            .unwrap_or_else(|_| (registry::lookup("minimax").unwrap(), "MiniMax-M3"));
+        assert_eq!(entry.id, "minimax");
+        assert_eq!(model, "MiniMax-M3");
     }
 
     #[test]


### PR DESCRIPTION
Reason: Add MiniMax as a built-in text provider.

Changes:
- Register MiniMax as an OpenAI-compatible provider with the global API endpoint.
- Add MiniMax-M3 and MiniMax-M2.7 context windows and default model routing.
- Cover the global endpoint, regional endpoint override, registry lookup, and auto-detection behavior.

Checks:
- rustfmt crates/cersei-provider/src/registry.rs crates/cersei-provider/src/router.rs
- git diff --check
- cargo test -p cersei-provider -- --test-threads=1

Note:
- cargo fmt --all --check was run first and failed on pre-existing formatting differences outside the touched provider files.
