### PR TITLE
docs: add Parallel Search MCP setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,12 @@ Agent::builder()
 let mcp = McpManager::connect(&[
     McpServerConfig::stdio("db", "npx", &["-y", "@my/db-mcp"]),
     McpServerConfig::sse("docs", "https://mcp.example.com"),
+    // Remote Streamable HTTP MCP via a stdio bridge; no account or API key required.
+    McpServerConfig::stdio(
+        "parallel-search",
+        "npx",
+        &["-y", "mcp-remote", "https://search.parallel.ai/mcp"],
+    ),
 ]).await?;
 
 Agent::builder().tools(mcp.tool_definitions().await)


### PR DESCRIPTION
Users who want current web search in Cersei can connect Parallel's remote MCP endpoint without an account or API key. This adds a copyable configuration alongside the existing MCP examples and leaves the built-in web tools unchanged.

## What changed

- Added a `parallel-search` stdio configuration using `mcp-remote`.
- Pointed the configuration at the free Parallel Search MCP endpoint.

## Validation

- Verified the exact configuration, endpoint, and incumbent example order.
- Ran `git diff --check`.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.