### PR TITLE
Fix UTF-8 character boundary handling across Cersei

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ url = "2"
 
 # Text processing
 similar = "2"
+unicode-segmentation = "1"
 unicode-width = "0.2"
 
 # HTML processing

--- a/crates/abstract-cli/Cargo.toml
+++ b/crates/abstract-cli/Cargo.toml
@@ -44,6 +44,8 @@ termimad = "0.30"
 # Markdown + Syntax Highlighting
 pulldown-cmark = "0.12"
 syntect = { version = "5", features = ["default-syntaxes", "default-themes"] }
+unicode-segmentation = { workspace = true }
+unicode-width = { workspace = true }
 
 # Input (legacy — kept for non-TUI fallback)
 rustyline = "15"

--- a/crates/abstract-cli/src/sessions.rs
+++ b/crates/abstract-cli/src/sessions.rs
@@ -70,7 +70,7 @@ pub fn list(config: &AppConfig) -> anyhow::Result<()> {
             .unwrap_or_else(|| "unknown".into());
 
         let display_name = if name.len() > 38 {
-            format!("{}...", &name[..35])
+            format!("{}...", truncate_at_char_boundary(name, 35))
         } else {
             name.clone()
         };
@@ -80,6 +80,14 @@ pub fn list(config: &AppConfig) -> anyhow::Result<()> {
 
     println!("\n{} session(s)", entries.len());
     Ok(())
+}
+
+fn truncate_at_char_boundary(text: &str, max_bytes: usize) -> &str {
+    let mut end = max_bytes.min(text.len());
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    &text[..end]
 }
 
 /// Show a session transcript.

--- a/crates/abstract-cli/src/tui/markdown.rs
+++ b/crates/abstract-cli/src/tui/markdown.rs
@@ -6,6 +6,8 @@ use std::sync::OnceLock;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSet;
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 static SYNTAX_SET: OnceLock<SyntaxSet> = OnceLock::new();
 static THEME_SET: OnceLock<ThemeSet> = OnceLock::new();
@@ -163,51 +165,39 @@ pub fn render_markdown(text: &str, width: u16) -> Vec<Line<'static>> {
 
     flush_line(&mut lines, &mut current_spans);
 
-    // Wrap lines that exceed terminal width
+    // Wrap lines that exceed terminal width. UTF-8 byte length is neither a
+    // character count nor a terminal column width, so work one grapheme at a
+    // time and use its display width instead.
     if max_width > 0 {
         let mut wrapped = Vec::with_capacity(lines.len());
         for line in lines {
-            let line_width: usize = line.spans.iter().map(|s| s.content.len()).sum();
+            let line_width: usize = line.spans.iter().map(|s| s.content.width()).sum();
             if line_width <= max_width {
                 wrapped.push(line);
             } else {
-                // Split long line into multiple lines
                 let mut current_width = 0usize;
                 let mut current_spans: Vec<Span<'static>> = Vec::new();
                 for span in line.spans {
-                    let span_len = span.content.len();
-                    if current_width + span_len <= max_width {
-                        current_width += span_len;
-                        current_spans.push(span);
-                    } else {
-                        // Need to split this span
-                        let remaining = max_width.saturating_sub(current_width);
-                        if remaining > 0 {
-                            let text = span.content.to_string();
-                            let (first, rest) = text.split_at(remaining.min(text.len()));
-                            if !first.is_empty() {
-                                current_spans.push(Span::styled(first.to_string(), span.style));
+                    let mut fragment = String::new();
+                    for grapheme in span.content.graphemes(true) {
+                        let grapheme_width = grapheme.width();
+                        if current_width > 0 && current_width + grapheme_width > max_width {
+                            if !fragment.is_empty() {
+                                current_spans
+                                    .push(Span::styled(std::mem::take(&mut fragment), span.style));
                             }
                             wrapped.push(Line::from(std::mem::take(&mut current_spans)));
-                            // Continue with rest of span
-                            let mut leftover = rest.to_string();
-                            while leftover.len() > max_width {
-                                let (chunk, rem) = leftover.split_at(max_width);
-                                wrapped
-                                    .push(Line::from(Span::styled(chunk.to_string(), span.style)));
-                                leftover = rem.to_string();
-                            }
-                            if !leftover.is_empty() {
-                                current_spans.push(Span::styled(leftover, span.style));
-                                current_width = current_spans.iter().map(|s| s.content.len()).sum();
-                            } else {
-                                current_width = 0;
-                            }
-                        } else {
-                            wrapped.push(Line::from(std::mem::take(&mut current_spans)));
-                            current_spans.push(span);
-                            current_width = span_len;
+                            current_width = 0;
                         }
+
+                        // A single grapheme can be wider than the available
+                        // space (for example a wide CJK glyph in a one-column
+                        // terminal). Keep it intact and make forward progress.
+                        fragment.push_str(grapheme);
+                        current_width += grapheme_width;
+                    }
+                    if !fragment.is_empty() {
+                        current_spans.push(Span::styled(fragment, span.style));
                     }
                 }
                 if !current_spans.is_empty() {
@@ -218,6 +208,43 @@ pub fn render_markdown(text: &str, width: u16) -> Vec<Line<'static>> {
         wrapped
     } else {
         lines
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text_of(line: &Line<'static>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect()
+    }
+
+    #[test]
+    fn wraps_unicode_without_splitting_graphemes() {
+        let input = "e\u{301}漢🙂\u{200d}💻";
+        let lines = render_markdown(input, 2);
+        let rendered: String = lines.iter().map(text_of).collect();
+
+        assert_eq!(rendered, input);
+
+        let mut consumed = 0;
+        for line in lines {
+            let line_text = text_of(&line);
+            if line_text.is_empty() {
+                continue;
+            }
+            consumed += line_text.len();
+            assert!(
+                consumed == input.len()
+                    || input
+                        .grapheme_indices(true)
+                        .any(|(index, _)| index == consumed),
+                "line ends inside a grapheme cluster"
+            );
+        }
     }
 }
 

--- a/crates/abstract-cli/src/tui/widgets/side_panel.rs
+++ b/crates/abstract-cli/src/tui/widgets/side_panel.rs
@@ -315,8 +315,17 @@ pub fn refresh_content(state: &mut AppState, working_dir: &std::path::Path) {
             if line.len() < 4 {
                 return line.to_string();
             }
-            let code = &line[..2];
-            let file = line[3..].trim();
+            // Floor the 2-byte code slice to a valid UTF-8 char boundary.
+            // git status lines can be preceded by filenames containing
+            // multibyte characters in edge cases; this guards against
+            // panicking mid-character (fixes the "end byte index is not
+            // a char boundary" crash).
+            let mut limit = 2.min(line.len());
+            while limit > 0 && !line.is_char_boundary(limit) {
+                limit -= 1;
+            }
+            let code = &line[..limit];
+            let file = line.get(3..).unwrap_or("").trim();
             match code.trim() {
                 "??" => format!("  untracked  {file}"),
                 "M" | " M" => format!("  modified   {file}"),

--- a/crates/abstract-cli/src/tui/widgets/side_panel.rs
+++ b/crates/abstract-cli/src/tui/widgets/side_panel.rs
@@ -315,16 +315,9 @@ pub fn refresh_content(state: &mut AppState, working_dir: &std::path::Path) {
             if line.len() < 4 {
                 return line.to_string();
             }
-            // Floor the 2-byte code slice to a valid UTF-8 char boundary.
-            // git status lines can be preceded by filenames containing
-            // multibyte characters in edge cases; this guards against
-            // panicking mid-character (fixes the "end byte index is not
-            // a char boundary" crash).
-            let mut limit = 2.min(line.len());
-            while limit > 0 && !line.is_char_boundary(limit) {
-                limit -= 1;
-            }
-            let code = &line[..limit];
+            // `git status --short` reserves its first two ASCII bytes for the
+            // status code. `get` keeps the parsing safe for malformed output.
+            let code = line.get(..2).unwrap_or("");
             let file = line.get(3..).unwrap_or("").trim();
             match code.trim() {
                 "??" => format!("  untracked  {file}"),

--- a/crates/cersei-agentrl/src/graph.rs
+++ b/crates/cersei-agentrl/src/graph.rs
@@ -236,8 +236,16 @@ impl FailureTrace {
 pub(crate) fn summarize_input(input: &Value) -> String {
     let s = input.to_string();
     if s.len() > EXCERPT_MAX {
-        format!("{}…", &s[..EXCERPT_MAX])
+        format!("{}…", &s[..floor_char_boundary(&s, EXCERPT_MAX)])
     } else {
         s
     }
+}
+
+fn floor_char_boundary(text: &str, max_bytes: usize) -> usize {
+    let mut end = max_bytes.min(text.len());
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
 }

--- a/crates/cersei-agentrl/src/verify.rs
+++ b/crates/cersei-agentrl/src/verify.rs
@@ -213,8 +213,16 @@ fn truncate(s: &str, n: usize) -> String {
     if s.len() <= n {
         s.to_string()
     } else {
-        format!("{}…", &s[..n])
+        format!("{}…", &s[..floor_char_boundary(s, n)])
     }
+}
+
+fn floor_char_boundary(text: &str, max_bytes: usize) -> usize {
+    let mut end = max_bytes.min(text.len());
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
 }
 
 #[cfg(test)]

--- a/crates/cersei-memory/src/memdir.rs
+++ b/crates/cersei-memory/src/memdir.rs
@@ -237,7 +237,7 @@ pub fn load_memory_index(memory_dir: &Path) -> Option<MemoryIndex> {
     let output = if truncated {
         let mut result: String = lines[..MAX_INDEX_LINES.min(total_lines)].join("\n");
         if result.len() > MAX_INDEX_BYTES {
-            result.truncate(MAX_INDEX_BYTES);
+            result.truncate(floor_char_boundary(&result, MAX_INDEX_BYTES));
         }
         result.push_str(&format!(
             "\n\n<!-- MEMORY.md truncated: {} total lines, showing {} -->",
@@ -254,6 +254,14 @@ pub fn load_memory_index(memory_dir: &Path) -> Option<MemoryIndex> {
         truncated,
         total_lines,
     })
+}
+
+fn floor_char_boundary(text: &str, max_bytes: usize) -> usize {
+    let mut end = max_bytes.min(text.len());
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
 }
 
 /// Build the complete memory prompt content for the system prompt.

--- a/crates/cersei-tools/src/exa_search.rs
+++ b/crates/cersei-tools/src/exa_search.rs
@@ -345,12 +345,20 @@ fn extract_snippet(result: &ExaResult) -> String {
             // Truncate long text to a reasonable snippet length
             let max_snippet = 500;
             if text.len() > max_snippet {
-                return format!("{}...", &text[..max_snippet]);
+                return format!("{}...", &text[..floor_char_boundary(text, max_snippet)]);
             }
             return text.clone();
         }
     }
     String::new()
+}
+
+fn floor_char_boundary(text: &str, max_bytes: usize) -> usize {
+    let mut end = max_bytes.min(text.len());
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
 }
 
 #[cfg(test)]

--- a/crates/cersei-tools/src/skills/mod.rs
+++ b/crates/cersei-tools/src/skills/mod.rs
@@ -127,13 +127,21 @@ pub fn extract_description(content: &str) -> String {
         // Strip heading markers
         let trimmed = trimmed.trim_start_matches('#').trim();
         let desc = if trimmed.len() > 80 {
-            format!("{}...", &trimmed[..77])
+            format!("{}...", &trimmed[..floor_char_boundary(trimmed, 77)])
         } else {
             trimmed.to_string()
         };
         return desc;
     }
     String::new()
+}
+
+fn floor_char_boundary(text: &str, max_bytes: usize) -> usize {
+    let mut end = max_bytes.min(text.len());
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
 }
 
 #[cfg(test)]

--- a/crates/cersei-tools/src/tool_primitives/http.rs
+++ b/crates/cersei-tools/src/tool_primitives/http.rs
@@ -151,10 +151,11 @@ pub async fn post(url: &str, body: &str, opts: HttpOptions) -> Result<HttpRespon
 }
 
 /// Fetch a URL and convert HTML to readable plain text.
-/// Non-HTML content is returned as-is. Truncated to `max_chars`.
+/// Non-HTML content is returned as-is. Truncated to at most `max_bytes`
+/// without splitting a UTF-8 character.
 pub async fn fetch_html(
     url: &str,
-    max_chars: usize,
+    max_bytes: usize,
     opts: HttpOptions,
 ) -> Result<String, HttpError> {
     let resp = get(url, opts).await?;
@@ -171,9 +172,17 @@ pub async fn fetch_html(
         resp.body
     };
 
-    if text.len() > max_chars {
-        Ok(text[..max_chars].to_string())
+    if text.len() > max_bytes {
+        Ok(text[..floor_char_boundary(&text, max_bytes)].to_string())
     } else {
         Ok(text)
     }
+}
+
+fn floor_char_boundary(text: &str, max_bytes: usize) -> usize {
+    let mut end = max_bytes.min(text.len());
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
 }


### PR DESCRIPTION
Fixes several UTF-8 crashes caused by unsafe string slicing on user-facing text

Changes:
- replace unsafe byte slicing with UTF-8 boundary-safe handling
- make markdown wrapping aware of Unicode grapheme clusters and terminal width
- fix truncation points in sessions, memory, tools and agentrl
- make git status parsing safer in the side panel

Abstract behavior remains unchanged