### PR TITLE
fix: round-trip redacted_thinking blocks from the Anthropic stream

### DIFF
--- a/crates/cersei-provider/src/anthropic.rs
+++ b/crates/cersei-provider/src/anthropic.rs
@@ -549,12 +549,27 @@ fn parse_sse_event(raw: &str) -> Option<StreamEvent> {
                 .as_str()
                 .unwrap_or("text")
                 .to_string();
-            Some(StreamEvent::ContentBlockStart {
-                index,
-                block_type,
-                id: json["content_block"]["id"].as_str().map(String::from),
-                name: json["content_block"]["name"].as_str().map(String::from),
-            })
+            // A `redacted_thinking` block carries its entire opaque payload
+            // right here on the start event — there are no deltas for it.
+            // Route it to a dedicated event so the accumulator can round-trip
+            // it; falling through as a generic start used to reduce the block
+            // to empty `Text` in history, which the API rejects (#21).
+            if block_type == "redacted_thinking" {
+                Some(StreamEvent::RedactedThinking {
+                    index,
+                    data: json["content_block"]["data"]
+                        .as_str()
+                        .unwrap_or("")
+                        .to_string(),
+                })
+            } else {
+                Some(StreamEvent::ContentBlockStart {
+                    index,
+                    block_type,
+                    id: json["content_block"]["id"].as_str().map(String::from),
+                    name: json["content_block"]["name"].as_str().map(String::from),
+                })
+            }
         }
         "content_block_delta" => {
             let index = json["index"].as_u64().unwrap_or(0) as usize;
@@ -712,6 +727,22 @@ mod tests {
                 assert_eq!(signature, "EqQBCgIY");
             }
             other => panic!("signature_delta must parse to SignatureDelta, got {other:?}"),
+        }
+    }
+
+    /// #21 (second half): a `redacted_thinking` block delivers its entire
+    /// opaque payload on `content_block_start` — there are no deltas for it.
+    /// The reader must map it to a dedicated event; as a generic start it
+    /// reaches the accumulator's fallthrough and comes back as empty `Text`.
+    #[test]
+    fn sse_redacted_thinking_start_carries_its_payload() {
+        let raw = "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"redacted_thinking\",\"data\":\"EmwKAhgBEgy3va\"}}";
+        match parse_sse_event(raw) {
+            Some(StreamEvent::RedactedThinking { index, data }) => {
+                assert_eq!(index, 0);
+                assert_eq!(data, "EmwKAhgBEgy3va");
+            }
+            other => panic!("redacted_thinking must parse to RedactedThinking, got {other:?}"),
         }
     }
 

--- a/crates/cersei-provider/src/stream.rs
+++ b/crates/cersei-provider/src/stream.rs
@@ -10,6 +10,9 @@ pub struct StreamAccumulator {
     partial_json: HashMap<usize, String>,
     partial_thinking: HashMap<usize, String>,
     partial_signature: HashMap<usize, String>,
+    /// Opaque `redacted_thinking` payloads, keyed by block index. Captured
+    /// whole from the start event (redacted blocks have no deltas).
+    partial_redacted_data: HashMap<usize, String>,
     block_types: HashMap<usize, String>,
     tool_use_ids: HashMap<usize, String>,
     tool_use_names: HashMap<usize, String>,
@@ -34,6 +37,7 @@ impl StreamAccumulator {
             partial_json: HashMap::new(),
             partial_thinking: HashMap::new(),
             partial_signature: HashMap::new(),
+            partial_redacted_data: HashMap::new(),
             block_types: HashMap::new(),
             tool_use_ids: HashMap::new(),
             tool_use_names: HashMap::new(),
@@ -96,6 +100,13 @@ impl StreamAccumulator {
                     .or_default()
                     .push_str(&signature);
             }
+            StreamEvent::RedactedThinking { index, data } => {
+                // No `ContentBlockStart` is emitted for redacted blocks, so
+                // register the block type here as well as the payload.
+                self.block_types
+                    .insert(index, "redacted_thinking".to_string());
+                self.partial_redacted_data.insert(index, data);
+            }
             StreamEvent::ContentBlockStop { index } => {
                 let block_type = self.block_types.get(&index).cloned().unwrap_or_default();
                 let block = match block_type.as_str() {
@@ -138,6 +149,13 @@ impl StreamAccumulator {
                         // gate on `ContentBlock::Thinking` omits the field
                         // from echoed history instead of sending `""`.
                         signature: self.partial_signature.remove(&index).unwrap_or_default(),
+                    },
+                    "redacted_thinking" => ContentBlock::RedactedThinking {
+                        // Echoed back verbatim so multi-turn history stays
+                        // valid. The pre-fix fallthrough reduced this block to
+                        // an empty `Text`, which the API rejects on the next
+                        // request (#21).
+                        data: self.partial_redacted_data.remove(&index).unwrap_or_default(),
                     },
                     _ => ContentBlock::Text {
                         text: self.partial_text.remove(&index).unwrap_or_default(),
@@ -487,6 +505,68 @@ mod tests {
         // And deserializing a signatureless block still works (serde default).
         let back: ContentBlock = serde_json::from_value(without).unwrap();
         assert!(matches!(back, ContentBlock::Thinking { .. }));
+    }
+
+    // ── #21 second half: redacted_thinking blocks round-trip verbatim ──
+
+    #[test]
+    fn redacted_thinking_survives_as_a_redacted_block_not_empty_text() {
+        // A redacted block first, then a text block — the redacted block's
+        // type registration must not depend on a `ContentBlockStart`, which
+        // is never emitted for it.
+        let response = accumulate(vec![
+            StreamEvent::MessageStart {
+                id: "msg_1".into(),
+                model: "test-model".into(),
+                usage: None,
+            },
+            StreamEvent::RedactedThinking {
+                index: 0,
+                data: "EmwKAhgBEgy3va".into(),
+            },
+            StreamEvent::ContentBlockStop { index: 0 },
+            StreamEvent::ContentBlockStart {
+                index: 1,
+                block_type: "text".into(),
+                id: None,
+                name: None,
+            },
+            StreamEvent::TextDelta {
+                index: 1,
+                text: "answer".into(),
+            },
+            StreamEvent::ContentBlockStop { index: 1 },
+            StreamEvent::MessageStop,
+        ])
+        .into_response()
+        .expect("valid stream");
+
+        let MessageContent::Blocks(blocks) = &response.message.content else {
+            panic!("expected blocks");
+        };
+        assert_eq!(blocks.len(), 2);
+        let ContentBlock::RedactedThinking { data } = &blocks[0] else {
+            panic!(
+                "a redacted_thinking block must survive accumulation, got {:?}",
+                blocks[0]
+            );
+        };
+        assert_eq!(
+            data, "EmwKAhgBEgy3va",
+            "the opaque payload must be echoed verbatim — losing it (or the \
+             pre-fix empty-`Text` reduction) invalidates resent history"
+        );
+        assert!(matches!(&blocks[1], ContentBlock::Text { text } if text == "answer"));
+    }
+
+    #[test]
+    fn redacted_block_serializes_to_its_wire_shape_for_history() {
+        let wire = serde_json::to_value(ContentBlock::RedactedThinking {
+            data: "EmwKAhgBEgy3va".into(),
+        })
+        .unwrap();
+        assert_eq!(wire["type"], "redacted_thinking");
+        assert_eq!(wire["data"], "EmwKAhgBEgy3va");
     }
 
     // ── F-05b at this seam: malformed JSON keeps the raw text and the error ──

--- a/crates/cersei-types/src/lib.rs
+++ b/crates/cersei-types/src/lib.rs
@@ -386,6 +386,14 @@ pub enum StreamEvent {
         index: usize,
         signature: String,
     },
+    /// A `redacted_thinking` block (Anthropic). Its opaque `data` payload
+    /// arrives complete on `content_block_start` — there are no deltas — and
+    /// must be echoed back verbatim in multi-turn history just like a thinking
+    /// signature, or the API rejects the resent conversation.
+    RedactedThinking {
+        index: usize,
+        data: String,
+    },
     ContentBlockStop {
         index: usize,
     },


### PR DESCRIPTION
## Summary

Addresses the remaining half of #21: streamed `redacted_thinking` blocks are now captured and round-tripped verbatim. The signature half (`signature_delta`) has been fixed on main since ff05b9b; the redacted half was still broken.

The failure mode was worse than a silent drop. A `redacted_thinking` block's opaque payload arrives entirely on `content_block_start` (there are no deltas for it), so the generic start handling registered the block type, captured nothing, and the accumulator's fallthrough then finalized the block as an empty `Text`. When that history is echoed on the next turn, the API rejects it: the empty text block is invalid, and the redacted block the API requires back is gone.

## Design

- New `StreamEvent::RedactedThinking { index, data }`, emitted by the SSE reader when `content_block_start` carries `content_block.type == "redacted_thinking"`. This mirrors how `SignatureDelta` got its own variant in the signature fix, rather than widening `ContentBlockStart` with a field only this block type uses (its ~25 construction sites across the workspace would all churn).
- `StreamAccumulator` registers the block type itself on that event (no `ContentBlockStart` is emitted for redacted blocks), stores the payload, and finalizes `ContentBlock::RedactedThinking { data }` on `content_block_stop`.
- The send path needs no changes: `ContentBlock::RedactedThinking` already serializes to the correct wire shape via serde.

## Tests

- `sse_redacted_thinking_start_carries_its_payload` (SSE reader mapping)
- `redacted_thinking_survives_as_a_redacted_block_not_empty_text` (accumulation, including a following text block, since redacted blocks emit no `ContentBlockStart`)
- `redacted_block_serializes_to_its_wire_shape_for_history`

`cargo test -p cersei-types -p cersei-provider`: all green, 0 failed (live-API tests ignored as usual). `cargo check --workspace --all-targets` clean.

Repro note: redacted thinking can be triggered deterministically with Anthropic's documented magic string (`ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB`) in a prompt with extended thinking plus tool use.
